### PR TITLE
[SECENG-364] Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/manual_test.yml
+++ b/.github/workflows/manual_test.yml
@@ -37,7 +37,7 @@ jobs:
       label: ${{ steps.create-runner.outputs.label }}
     steps:
       - id: create-runner
-        uses: related-sciences/gce-github-runner@main
+        uses: related-sciences/gce-github-runner@008d5e1348dc6f84ab73b7f723b7fb67a9fc706d # v0.14
         with:
           token: ${{ secrets.GH_SA_TOKEN }}
           project_id: ${{ secrets.GCP_PROJECT_ID }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       label: ${{ steps.create-runner.outputs.label }}
     steps:
       - id: create-runner
-        uses: related-sciences/gce-github-runner@main
+        uses: related-sciences/gce-github-runner@008d5e1348dc6f84ab73b7f723b7fb67a9fc706d # v0.14
         with:
           token: ${{ secrets.GH_SA_TOKEN }}
           project_id: ${{ secrets.GCP_PROJECT_ID }}


### PR DESCRIPTION
## Ticket
[SECENG-364](https://hoverinc.atlassian.net/browse/SECENG-364)

## Summary

Pin all GitHub Actions to commit SHAs for supply chain security. Branch-pinned actions (`@main` / `@master`) are upgraded to the repo's latest release tag.

### Pinned Actions

  - `related-sciences/gce-github-runner@v0.14` → [`008d5e13`](https://github.com/related-sciences/gce-github-runner/commit/008d5e1348dc6f84ab73b7f723b7fb67a9fc706d)


[SECENG-364]: https://hoverinc.atlassian.net/browse/SECENG-364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ